### PR TITLE
[Odoo 14] Replace action_view_invoice() with _prepare_invoice()

### DIFF
--- a/boraq_company_branches/__manifest__.py
+++ b/boraq_company_branches/__manifest__.py
@@ -13,7 +13,7 @@
     'author': "Boraq-Group",
     'website': "",
     'category': 'base',
-    'version': '14.0.1.0.0',
+    'version': '14.0.1.0.1',
     'depends': ['base','sale','account','purchase'],
     "images" : ['static/description/banner.png'],
     'data': [

--- a/boraq_company_branches/models/purchase_order.py
+++ b/boraq_company_branches/models/purchase_order.py
@@ -7,7 +7,11 @@ class PurchaseOrder(models.Model):
     branch_id = fields.Many2one('company.branches', string='Branch', domain="[('company_id','=',company_id)]")
     
     
-    def action_view_invoice(self):
-        result = super(PurchaseOrder,self).action_view_invoice()
-        result['context'].update({'default_branch_id':self.branch_id.id}) 
-        return result
+    def _prepare_invoice(self):
+        """ Override """
+        invoice_vals = super(PurchaseOrder, self)._prepare_invoice()
+        invoice_vals.update({
+            'branch_id': self.branch_id
+        })
+        return invoice_vals
+

--- a/boraq_company_branches/models/purchase_order.py
+++ b/boraq_company_branches/models/purchase_order.py
@@ -13,6 +13,5 @@ class PurchaseOrder(models.Model):
         invoice_vals.update({
             'branch_id': self.branch_id.id
         })
-        print('=============================================== invoice_vals', invoice_vals)
         return invoice_vals
 

--- a/boraq_company_branches/models/purchase_order.py
+++ b/boraq_company_branches/models/purchase_order.py
@@ -11,7 +11,8 @@ class PurchaseOrder(models.Model):
         """ Override """
         invoice_vals = super(PurchaseOrder, self)._prepare_invoice()
         invoice_vals.update({
-            'branch_id': self.branch_id
+            'branch_id': self.branch_id.id
         })
+        print('=============================================== invoice_vals', invoice_vals)
         return invoice_vals
 


### PR DESCRIPTION
- In purchase.order it is more appropriate to use _prepare_invoice() instead of action_view_invoice()
- `result['context'].update()` causes error in odoo 14